### PR TITLE
removed unnecessary viewmodel dependency in changefilepresenter

### DIFF
--- a/ffmpeg-gui/src/main/java/app/AppBuilder.java
+++ b/ffmpeg-gui/src/main/java/app/AppBuilder.java
@@ -118,7 +118,7 @@ public class AppBuilder {
 
     public AppBuilder addChangeFileUseCase(){
         final ChangeFileOutputBoundary changeFileOutputBoundary =
-                new ChangeFilePresenter(convertVideoFileViewModel, viewManagerModel, addInputFileViewModel);
+                new ChangeFilePresenter(viewManagerModel, addInputFileViewModel);
 
         final ChangeFileInputBoundary changeFileInteractor =
                 new ChangeFileInteractor(changeFileOutputBoundary);

--- a/ffmpeg-gui/src/main/java/interface_adapter/change_file/ChangeFilePresenter.java
+++ b/ffmpeg-gui/src/main/java/interface_adapter/change_file/ChangeFilePresenter.java
@@ -3,8 +3,6 @@ package interface_adapter.change_file;
 import interface_adapter.ViewManagerModel;
 import interface_adapter.add_input_file.AddInputFileState;
 import interface_adapter.add_input_file.AddInputFileViewModel;
-import interface_adapter.convert_video_file.ConvertVideoFileState;
-import interface_adapter.convert_video_file.ConvertVideoFileViewModel;
 import lombok.AllArgsConstructor;
 import use_case.change_file.ChangeFileOutputBoundary;
 import use_case.change_file.ChangeFileOutputData;
@@ -12,16 +10,11 @@ import use_case.change_file.ChangeFileOutputData;
 @AllArgsConstructor
 public class ChangeFilePresenter implements ChangeFileOutputBoundary {
 
-    private ConvertVideoFileViewModel convertVideoFileViewModel;
     private ViewManagerModel viewManagerModel;
     private AddInputFileViewModel addInputFileViewModel;
 
     @Override
     public void prepareSuccessView(ChangeFileOutputData changeFileOutputData) {
-        final ConvertVideoFileState convertVideoFileState = convertVideoFileViewModel.getState();
-        convertVideoFileViewModel.setState(convertVideoFileState);
-        convertVideoFileViewModel.firePropertyChanged();
-
         final AddInputFileState addInputFileState = addInputFileViewModel.getState();
         addInputFileState.setFileError("");
         addInputFileState.setFilePath(changeFileOutputData.getPath());

--- a/ffmpeg-gui/src/main/java/use_case/change_file/ChangeFileInputData.java
+++ b/ffmpeg-gui/src/main/java/use_case/change_file/ChangeFileInputData.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @AllArgsConstructor
+@Getter
 public class ChangeFileInputData {
-    @Getter
-    private final String Path;
+    private final String path;
 }

--- a/ffmpeg-gui/src/main/java/use_case/change_file/ChangeFileInteractor.java
+++ b/ffmpeg-gui/src/main/java/use_case/change_file/ChangeFileInteractor.java
@@ -7,8 +7,8 @@ public class ChangeFileInteractor implements ChangeFileInputBoundary{
     private ChangeFileOutputBoundary changeFilePresenter;
     @Override
     public void execute(ChangeFileInputData changeFileInputData) {
-        final String Path = changeFileInputData.getPath();
-        final ChangeFileOutputData changeFileOutputData = new ChangeFileOutputData(Path, false);
+        final String path = changeFileInputData.getPath();
+        final ChangeFileOutputData changeFileOutputData = new ChangeFileOutputData(path, false);
         changeFilePresenter.prepareSuccessView(changeFileOutputData);
     }
 }

--- a/ffmpeg-gui/src/main/java/use_case/change_file/ChangeFileOutputData.java
+++ b/ffmpeg-gui/src/main/java/use_case/change_file/ChangeFileOutputData.java
@@ -3,13 +3,12 @@ package use_case.change_file;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import org.checkerframework.checker.index.qual.GTENegativeOne;
 
 @Getter
 @AllArgsConstructor
 public class ChangeFileOutputData {
     @Setter
-    private String Path;
+    private String path;
     private boolean useCaseFailed;
 
 }

--- a/ffmpeg-gui/src/main/java/use_case/convert_video/ConvertVideoFileInteractor.java
+++ b/ffmpeg-gui/src/main/java/use_case/convert_video/ConvertVideoFileInteractor.java
@@ -34,7 +34,7 @@ public class ConvertVideoFileInteractor implements ConvertVideoFileInputBoundary
         }catch(BadFileException e){
             this.convertVideoFileOutputBoundary.prepareFailView("Invalid or null file path");
         } catch (IllegalArgumentException e){
-            this.convertVideoFileOutputBoundary.prepareFailView("Error occurred when processing: possibly invalid codec/format combination");
+            this.convertVideoFileOutputBoundary.prepareFailView("Error occurred when processing: invalid argument");
         } catch (Exception e) {
             this.convertVideoFileOutputBoundary.prepareFailView("Unexpected error occurred.");
         }


### PR DESCRIPTION
ChangeFilePresenter previously would perform an unnecessary setState operation on the ConvertVideoViewModel in prepareSuccessView. this operation isn't necessary since we reset the state when we enter the presenter of addInputFile anyway.